### PR TITLE
Fix issue when a table has only one column

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-super-responsive-table",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "React Super Responsive Table",
   "main": "dist/SuperResponsiveTable.js",
   "author": "The University Of Alabama",

--- a/src/SuperResponsiveTable.js
+++ b/src/SuperResponsiveTable.js
@@ -43,7 +43,7 @@ class TrInner extends React.Component {
     super(props)
     const { headers } = props.responsiveTable
     if (headers && props.inHeader) {
-      props.children.map((child, i) => {
+      React.Children.map(props.children, (child, i) => {
         headers[i] = child.props.children
       })
     }

--- a/test/SuperResponsiveTable.test.js
+++ b/test/SuperResponsiveTable.test.js
@@ -27,3 +27,38 @@ test('Render Table', () => {
   )
   expect(wrapper).toMatchSnapshot()
 })
+
+
+test('Render table with an only one column', () => {
+  const wrapper = shallow(
+    <Table>
+      <Thead>
+      <Tr>
+        <Th>Annual Conference</Th>
+      </Tr>
+      </Thead>
+      <Tbody>
+      <Tr>
+        <Td>31</Td>
+      </Tr>
+      </Tbody>
+    </Table>
+  )
+  expect(wrapper).toMatchSnapshot()
+})
+
+test('Render table without any column', () => {
+  const wrapper = shallow(
+    <Table>
+      <Thead>
+      <Tr>
+      </Tr>
+      </Thead>
+      <Tbody>
+      <Tr>
+      </Tr>
+      </Tbody>
+    </Table>
+  )
+  expect(wrapper).toMatchSnapshot()
+})

--- a/test/__snapshots__/SuperResponsiveTable.test.js.snap
+++ b/test/__snapshots__/SuperResponsiveTable.test.js.snap
@@ -51,3 +51,45 @@ exports[`Render Table 1`] = `
   </table>
 </ProvideContext>
 `;
+
+exports[`Render table with an only one column 1`] = `
+<ProvideContext
+  headers={Object {}}
+>
+  <table
+    className=" responsiveTable"
+  >
+    <Thead>
+      <WithContext(TrInner)>
+        <Th>
+          Annual Conference
+        </Th>
+      </WithContext(TrInner)>
+    </Thead>
+    <Tbody>
+      <WithContext(TrInner)>
+        <WithContext(TdInner)>
+          31
+        </WithContext(TdInner)>
+      </WithContext(TrInner)>
+    </Tbody>
+  </table>
+</ProvideContext>
+`;
+
+exports[`Render table without any column 1`] = `
+<ProvideContext
+  headers={Object {}}
+>
+  <table
+    className=" responsiveTable"
+  >
+    <Thead>
+      <WithContext(TrInner) />
+    </Thead>
+    <Tbody>
+      <WithContext(TrInner) />
+    </Tbody>
+  </table>
+</ProvideContext>
+`;


### PR DESCRIPTION
**Error:**

`props.children.map` will throw the following exception when it is only on child in `Tr`
```
new TrInner
node_modules/react-super-responsive-table/dist/SuperResponsiveTable.js:103
  100 | var headers = props.responsiveTable.headers;
  101 | 
  102 | if (headers && props.inHeader) {
> 103 |   props.children.map(function (child, i) {
      | ^  104 |     headers[i] = child.props.children;
  105 |   });
  106 | }
```

**Fix:**
Use top level api `React.Children.map` except `props.children.map`
