### PR TITLE
Check for conditional columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-super-responsive-table",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "description": "React Super Responsive Table",
   "main": "dist/SuperResponsiveTable.js",
   "author": "The University Of Alabama",

--- a/src/SuperResponsiveTable.js
+++ b/src/SuperResponsiveTable.js
@@ -44,7 +44,9 @@ class TrInner extends React.Component {
     const { headers } = props.responsiveTable
     if (headers && props.inHeader) {
       React.Children.map(props.children, (child, i) => {
-        headers[i] = child.props.children
+        if(child) {
+          headers[i] = child.props.children
+        }
       })
     }
   }
@@ -54,7 +56,7 @@ class TrInner extends React.Component {
       <tr {...allowed(this.props)}>
         {children &&
           React.Children.map(children, (child, i) =>
-            React.cloneElement(child, {
+            child && React.cloneElement(child, {
               key: i,
               columnKey: i,
             })

--- a/test/SuperResponsiveTable.test.js
+++ b/test/SuperResponsiveTable.test.js
@@ -82,3 +82,96 @@ test('Render table with only header and empty row', () => {
   expect(tree).toMatchSnapshot();
 })
 
+test('Render table with conditional column', () => {
+  let component = renderer.create(
+    <Table>
+      <Thead>
+      <Tr>
+        {false && <Td>Test Header Column</Td>}
+      </Tr>
+      </Thead>
+      <Tbody>
+      <Tr>
+        {false && <Td>Test Body Column</Td>}
+      </Tr>
+      </Tbody>
+    </Table>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+})
+
+test('Render table with conditional and unconditional column', () => {
+  let component = renderer.create(
+    <Table>
+      <Thead>
+      <Tr>
+        <Td>C1</Td>
+        {false && <Td>C2</Td>}
+        <Td>C3</Td>
+      </Tr>
+      </Thead>
+      <Tbody>
+      <Tr>
+        <Td>V1</Td>
+        {false && <Td>V2</Td>}
+        <Td>V3</Td>
+      </Tr>
+      </Tbody>
+    </Table>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+})
+
+test('Render table with more columns in body', () => {
+  let component = renderer.create(
+    <Table>
+      <Thead>
+      <Tr>
+        <Td>C1</Td>
+        {false && <Td>C2</Td>}
+        <Td>C3</Td>
+      </Tr>
+      </Thead>
+      <Tbody>
+      <Tr>
+        <Td>V1</Td>
+        {false && <Td>V2</Td>}
+        <Td>V3</Td>
+        <Td>V4</Td>
+        <Td>V5</Td>
+        <Td>V6</Td>
+      </Tr>
+      </Tbody>
+    </Table>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+})
+
+test('Render table with more columns in header', () => {
+  let component = renderer.create(
+    <Table>
+      <Thead>
+      <Tr>
+        <Td>C1</Td>
+        {false && <Td>C2</Td>}
+        <Td>C3</Td>
+        <Td>C4</Td>
+        <Td>C5</Td>
+        <Td>C6</Td>
+      </Tr>
+      </Thead>
+      <Tbody>
+      <Tr>
+        <Td>V1</Td>
+        {false && <Td>V2</Td>}
+        <Td>V3</Td>
+      </Tr>
+      </Tbody>
+    </Table>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+})

--- a/test/SuperResponsiveTable.test.js
+++ b/test/SuperResponsiveTable.test.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Table, Thead, Tbody, Tr, Th, Td } from '../src/SuperResponsiveTable'
+import renderer from 'react-test-renderer';
 
 test('Render Table', () => {
   const wrapper = shallow(
@@ -62,3 +63,22 @@ test('Render table without any column', () => {
   )
   expect(wrapper).toMatchSnapshot()
 })
+
+test('Render table with only header and empty row', () => {
+  let component = renderer.create(
+    <Table>
+      <Thead>
+      <Tr>
+        <Td>Test Column</Td>
+      </Tr>
+      </Thead>
+      <Tbody>
+      <Tr>
+      </Tr>
+      </Tbody>
+    </Table>
+  );
+  const tree = component.toJSON();
+  expect(tree).toMatchSnapshot();
+})
+

--- a/test/__snapshots__/SuperResponsiveTable.test.js.snap
+++ b/test/__snapshots__/SuperResponsiveTable.test.js.snap
@@ -77,6 +77,262 @@ exports[`Render table with an only one column 1`] = `
 </ProvideContext>
 `;
 
+exports[`Render table with conditional and unconditional column 1`] = `
+<table
+  className=" responsiveTable"
+>
+  <thead>
+    <tr>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C1
+        </div>
+        C1
+      </td>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C3
+        </div>
+        C3
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C1
+        </div>
+        V1
+      </td>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C3
+        </div>
+        V3
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`Render table with conditional column 1`] = `
+<table
+  className=" responsiveTable"
+>
+  <thead>
+    <tr />
+  </thead>
+  <tbody>
+    <tr />
+  </tbody>
+</table>
+`;
+
+exports[`Render table with more columns in body 1`] = `
+<table
+  className=" responsiveTable"
+>
+  <thead>
+    <tr>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C1
+        </div>
+        C1
+      </td>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C3
+        </div>
+        C3
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C1
+        </div>
+        V1
+      </td>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C3
+        </div>
+        V3
+      </td>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        />
+        V4
+      </td>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        />
+        V5
+      </td>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        />
+        V6
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`Render table with more columns in header 1`] = `
+<table
+  className=" responsiveTable"
+>
+  <thead>
+    <tr>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C1
+        </div>
+        C1
+      </td>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C3
+        </div>
+        C3
+      </td>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C4
+        </div>
+        C4
+      </td>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C5
+        </div>
+        C5
+      </td>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C6
+        </div>
+        C6
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C1
+        </div>
+        V1
+      </td>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          C3
+        </div>
+        V3
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`Render table with only header and empty row 1`] = `
+<table
+  className=" responsiveTable"
+>
+  <thead>
+    <tr>
+      <td
+        className=" pivoted"
+      >
+        <div
+          className="tdBefore"
+        >
+          Test Column
+        </div>
+        Test Column
+      </td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr />
+  </tbody>
+</table>
+`;
+
 exports[`Render table without any column 1`] = `
 <ProvideContext
   headers={Object {}}


### PR DESCRIPTION
Bug:
It is not possible to use conditional columns:
`{false && <Td>Column</td>}`

Error:
```
Uncaught Error: React.cloneElement(...): The argument must be a React element, but you passed null.
    at invariant (:3000/static/js/vendors.chunk.js:50842)
    at Object.cloneElement (:3000/static/js/vendors.chunk.js:158017)
    at Object.cloneElementWithValidation [as cloneElement] (:3000/static/js/vendors.chunk.js:158886)
    at :3000/static/js/vendors.chunk.js:142170
    at mapSingleChildIntoContext (:3000/static/js/vendors.chunk.js:158347)
```

Fix:
Check if child exists

Other changes:
- Add tests for more coverage
- Use `react-test-renderer` to be able to write a test for this issue
