### PR TITLE
Variable breakpoints

### DIFF
--- a/build-css-es.js
+++ b/build-css-es.js
@@ -1,0 +1,31 @@
+/**
+ * what this file does is to get css file as input, and change the breakpoint
+ * and re-write this for each required sizes (40em, 60em, 80em, etc...)
+ * then the user has to import
+ *  'react-super-res.../.../SuperResponsiveTableStyle_<size>.css'
+ * like
+ *   'react-super-res.../.../SuperResponsiveTableStyle_<60>.css'
+ */
+
+const FILE_NAME = 'SuperResponsiveTableStyle';
+
+const nodeFileSystem = require('fs');
+
+const file = nodeFileSystem.readFileSync(`./src/${FILE_NAME}.css`).toString();
+const lines = file.split('\n');
+
+const indexOfLineWhereBreakpointIsThere =
+    lines  // ugly, but works
+        .findIndex(line => line.indexOf('40em') > -1);
+
+[60, 80].forEach(size => {
+    const sizeLineReplaced =
+        lines[indexOfLineWhereBreakpointIsThere]
+            .replace('40em', size + 'em');
+    const newFileLines = lines.slice(0); // copy original lines
+    newFileLines[indexOfLineWhereBreakpointIsThere] = sizeLineReplaced;
+    
+    nodeFileSystem.appendFile('./dist/' + FILE_NAME + '_' + size + '.css', newFileLines.join('\n'), err => {
+        if (err) throw err;
+    });
+});

--- a/dist/SuperResponsiveTableStyle_60.css
+++ b/dist/SuperResponsiveTableStyle_60.css
@@ -1,0 +1,60 @@
+/* inspired by: https://css-tricks.com/responsive-data-tables/ */
+.responsiveTable {
+  width: 100%;
+}
+
+.responsiveTable td .tdBefore {
+  display: none;
+}
+
+@media screen and (max-width: 60em) {
+  /*
+    Force table elements to not behave like tables anymore
+    Hide table headers (but not display: none;, for accessibility)
+  */
+
+  .responsiveTable table,
+  .responsiveTable thead,
+  .responsiveTable tbody,
+  .responsiveTable th,
+  .responsiveTable td,
+  .responsiveTable tr {
+    display: block;
+  }
+
+  .responsiveTable thead tr {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+    border-bottom: 2px solid #333;
+  }
+
+  .responsiveTable tbody tr {
+    border: 1px solid #000;
+    padding: .25em;
+  }
+
+  .responsiveTable td.pivoted {
+    /* Behave like a "row" */
+    border: none !important;
+    position: relative;
+    padding-left: calc(50% + 10px) !important;
+    text-align: left !important;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+  }
+
+  .responsiveTable td .tdBefore {
+    /* Now like a table header */
+    position: absolute;
+    display: block;
+
+    /* Top/left values mimic padding */
+    left: 1rem;
+    width: calc(50% - 20px);
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    text-align: left !important;
+    font-weight: 600;
+  }
+}

--- a/dist/SuperResponsiveTableStyle_80.css
+++ b/dist/SuperResponsiveTableStyle_80.css
@@ -1,0 +1,60 @@
+/* inspired by: https://css-tricks.com/responsive-data-tables/ */
+.responsiveTable {
+  width: 100%;
+}
+
+.responsiveTable td .tdBefore {
+  display: none;
+}
+
+@media screen and (max-width: 80em) {
+  /*
+    Force table elements to not behave like tables anymore
+    Hide table headers (but not display: none;, for accessibility)
+  */
+
+  .responsiveTable table,
+  .responsiveTable thead,
+  .responsiveTable tbody,
+  .responsiveTable th,
+  .responsiveTable td,
+  .responsiveTable tr {
+    display: block;
+  }
+
+  .responsiveTable thead tr {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+    border-bottom: 2px solid #333;
+  }
+
+  .responsiveTable tbody tr {
+    border: 1px solid #000;
+    padding: .25em;
+  }
+
+  .responsiveTable td.pivoted {
+    /* Behave like a "row" */
+    border: none !important;
+    position: relative;
+    padding-left: calc(50% + 10px) !important;
+    text-align: left !important;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+  }
+
+  .responsiveTable td .tdBefore {
+    /* Now like a table header */
+    position: absolute;
+    display: block;
+
+    /* Top/left values mimic padding */
+    left: 1rem;
+    width: calc(50% - 20px);
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    text-align: left !important;
+    font-weight: 600;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,16 +22,16 @@
     "start": "next",
     "build-site": "next build",
     "build": "babel -d dist src --copy-files",
-    "clean": "rm -rf dist && mkdir dist",
+    "clean": "rimraf dist && mkdir dist",
     "export": "npm run build-site && next export",
     "watch": "babel -w -d dist src --copy-files",
-    "format": "prettier --trailing-comma es5 --no-semi --single-quote --write 'src/**/*.js'",
+    "format": "prettier --trailing-comma es5 --no-semi --single-quote --write \"src/**/*.js\"",
     "preversion": "npm run test && npm run format && npm run clean && npm run build && npm run build-site",
     "postpublish": "git push && git push --tag",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "coveralls": "jest --coverage && cat ./coverage/lcov.info | coveralls"
+    "coveralls": "jest --coverage && npx shx cat ./coverage/lcov.info | coveralls"
   },
   "jest": {
     "setupFiles": [
@@ -67,6 +67,8 @@
     "react-live": "^2.1.2",
     "react-test-renderer": "^16.8.6",
     "react-window-ui": "^2.1.0",
+    "rimraf": "^2.6.3",
+    "shx": "^0.3.2",
     "styled-components": "4.3.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "start": "next",
     "build-site": "next build",
-    "build": "babel -d dist src --copy-files",
+    "build": "babel -d dist src --copy-files && npm run build-css-es",
+    "build-css-es": "node build-css-es && echo DONE",
     "clean": "rimraf dist && mkdir dist",
     "export": "npm run build-site && next export",
     "watch": "babel -w -d dist src --copy-files",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,6 +2854,11 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es6-object-assign@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+  integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -3599,6 +3604,11 @@ ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+interpret@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
+  integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
@@ -6009,6 +6019,13 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
+
 recursive-copy@2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/recursive-copy/-/recursive-copy-2.0.6.tgz#d590f9eb5f165b96a1b80bc8f9cbcb5c6f9c89e9"
@@ -6210,6 +6227,13 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
+
+resolve@^1.1.6:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
+  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  dependencies:
+    path-parse "^1.0.6"
 
 resolve@^1.10.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.11.0"
@@ -6424,10 +6448,28 @@ shell-quote@^1.6.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
+shelljs@^0.8.1:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shx@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.2.tgz#40501ce14eb5e0cbcac7ddbd4b325563aad8c123"
+  integrity sha512-aS0mWtW3T2sHAenrSrip2XGv39O9dXIFUqxAEWHEOS1ePtGIBavdPJY1kE2IHl14V/4iCbUiNDPGdyYTtmhSoA==
+  dependencies:
+    es6-object-assign "^1.0.3"
+    minimist "^1.2.0"
+    shelljs "^0.8.1"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Hi!
I'm pretty sure you will reject this merge request. 😁

My problem was that I had a table with lots of columns each one having a long text in the cell.
So that `40em` you used in your `.css` was not useful for me. I wanted to have `60em` instead, because my table (content) was so big.

So what I did was, instead of doing:
```jsx
import 'react-super-responsive-table/dist/SuperResponsiveTableStyle.css';
```
in my file, I opened this file in my `node_modules` and copied the whole content to a file in my project and played with break-point size \`til I found `60em` to be working for me.

So I felt the need for a syntax like this: (note the **breakOn** or **breakLevel** attribute/prop)
```jsx
import React from 'react';
import { Table, Thead, Tbody, Tr, Th, Td } from 'react-super-responsive-table'
import 'react-super-responsive-table/dist/SuperResponsiveTableStyle.css'

export default function MyVirtualizedTable({ tableData }) {
    return <div>
        <Table breakOn={'600px'}> // or '40em' or like `breakLevel={2}` (in scale of 1 to 10)
            <Thead>
                <Tr>
                    ...
```

Or maybe just provide some classes like `rsrt-60em`, `rsrt-600px` or `rsrt-2` (**rsrt** stands for `react-super-responsive-table`) which automatically makes table break into responsive mode when corresponding break-point reaches.

The first method (using attributes/props) can be done maybe using **styled-jsx** (I'm not sure, I did not think about it) and the second method (using classes) can be done using **Sass**.

Both methods seem like standard.

But in this merge request I did none. (that's why I'm pretty sure it would be rejected 😁)

I just duplicated that `.css` file to three different variants. (one using `60em` and one using `80em`)
So that user of library could do:
```jsx
import 'react-super-responsive-table/dist/SuperResponsiveTableStyle.css'; // 40em break-point
// or ...
import 'react-super-responsive-table/dist/SuperResponsiveTableStyle_60.css'; // 60em break-point
// or ...
import 'react-super-responsive-table/dist/SuperResponsiveTableStyle_80.css'; // 80em break-point
```

I know it is super ugly, but I just wanted to point out the issue. So consider this an issue rather than a merge request. As I'm not sure when I would find time to make it right, I just did it and pushed it here. (so to make this issue come alive and into consideration)

Also another (maybe) bad thing about this merge request is that I merged https://github.com/ua-oira/react-super-responsive-table/pull/107 into this, because I needed it.
So it is a little busier than it should be. (unless https://github.com/ua-oira/react-super-responsive-table/pull/107 be merged)

Also about the build system:
It accepts an array (currently hard-coded `[60, 80]`) and for each member of that array (let's call it `size`) it would create the corresponding `SuperResponsiveTableStyle_<size>.css` file into `dist` folder which breaks the table on `<size>em` break-point.

😁👍