### PR TITLE
Add option to set a custom breakpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ react-super-responsive-table converts your table data to a user-friendly list in
 
 ## Demo
 
-![Demo Gif](https://user-images.githubusercontent.com/7424180/55982530-baab9900-5c5e-11e9-97c0-0336c5889504.gif)
+![Demo Gif](https://user-images.githubusercontent.com/7394331/76696169-59d4de00-66c3-11ea-843f-85aa9e227d79.gif)
 
 Live demo: [https://react-super-responsive-table.netlify.com](https://react-super-responsive-table.netlify.com)
 
@@ -31,17 +31,16 @@ npm install react-super-responsive-table --save
 ## Usage
 
 1. `import { Table, Thead, Tbody, Tr, Th, Td } from 'react-super-responsive-table'`
-2. Copy or import `react-super-responsive-table/dist/superResponsiveTableStyles.css` into your project
+2. To enable the base table styles, set the `withBaseStyles` prop on the `Table` component. You may optionally use it to define a custom breakpoint: `<Table withBaseStyles={{ breakpoint: '45em' }} />`.
 3. Write your html table with the imported components.
 
 ```jsx
 import React from 'react'
 import { Table, Thead, Tbody, Tr, Th, Td } from 'react-super-responsive-table'
-import 'react-super-responsive-table/dist/SuperResponsiveTableStyle.css'
 
 export default function TableExample(props) {
   return (
-    <Table>
+    <Table withBaseStyles>
       <Thead>
         <Tr>
           <Th>Event</Th>

--- a/README.md
+++ b/README.md
@@ -91,6 +91,27 @@ Headers are statefully stored on first render of the table, since the library do
 </Table>
 ```
 
+## Styling
+
+All the underlying table elements have [BEM class names](https://en.bem.info/methodology/naming-convention/) that you can use to target each element for styling.
+
+```html
+<table class="super-responsive-table__table">
+  <thead class="super-responsive-table__thead">
+    <tr class="super-responsive-table__tr">
+      <th class="super-responsive-table__th" />
+    </tr>
+  </thead>
+  <tbody class="super-responsive-table__tbody">
+    <tr class="super-responsive-table__tr">
+      <td class="super-responsive-table__td" />
+    </tr>
+  </tbody>
+</table>
+```
+
+Once the table has pivoted into its side-by-side layout, the `<th>` and `<td>` elements will also be appended the `super-responsive-table__th_pivoted` and `super-responsive-table__td_pivoted` modifier class names respectively.
+
 ## Contributors
 
 Super Responsive Tables are made possible by these great community members:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ react-super-responsive-table converts your table data to a user-friendly list in
 - [Installation](#installation)
 - [Usage](#usage)
 - [Using Dynamic Headers](#using-dynamic-headers)
+- [Styling](#styling)
 - [Contributors](#Contributors)
 - [Contributing](#contributing)
 - [License](#license)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ react-super-responsive-table converts your table data to a user-friendly list in
 
 ## Demo
 
-![Demo Gif](https://user-images.githubusercontent.com/7394331/76696169-59d4de00-66c3-11ea-843f-85aa9e227d79.gif)
+![Demo Gif](https://user-images.githubusercontent.com/7394331/76912688-b74d7280-68ef-11ea-8ef5-65595e9fe440.gif)
 
 Live demo: [https://react-super-responsive-table.netlify.com](https://react-super-responsive-table.netlify.com)
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -240,8 +240,9 @@ const headerCode = `
       }
 
       .super-responsive-table__th_pivoted {
-        padding: 0.75rem;
-        font-weight: bold;
+        background: none;
+        border: none;
+        color: #000;
       }
     }
   \`}</style>

--- a/pages/index.js
+++ b/pages/index.js
@@ -239,7 +239,7 @@ const headerCode = `
         border: none;
       }
 
-      .super-responsive-table__th_pseudo {
+      .super-responsive-table__th_pivoted {
         padding: 0.75rem;
         font-weight: bold;
       }

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,6 @@ import {
   Th,
   Td
 } from "../src/SuperResponsiveTable.js";
-import "../src/SuperResponsiveTableStyle.css";
 
 class App extends React.Component {
   render() {
@@ -46,33 +45,6 @@ class App extends React.Component {
             }
             ul li, ol li {
               line-height:140%; 
-            }
-            table {
-                border-collapse: collapse;
-                background:rgba(255,255,255,0.4);
-            }
-
-            th,
-            td {
-                border: 1px solid #000;
-                padding: 0.75rem;
-                text-align: left;
-            }
-
-            th {
-                font-weight: bold;
-                white-space: nowrap;
-                background: #000;
-                color: #fff;
-            }
-
-            tr:first-of-type th:not(:last-child) {
-                border-right-color: transparent;
-            }
-
-            tr:first-child th:first-child,
-            tr:not(:first-child):not(:last-child) th {
-                border-bottom-color: transparent !important;
             }
     `}</style>
 
@@ -132,6 +104,7 @@ class App extends React.Component {
           <LiveProvider
             code={headerCode}
             scope={{
+              style: 'style',
               Table,
               Thead,
               Tbody,
@@ -181,9 +154,16 @@ class App extends React.Component {
                 </code>
               </li>
               <li>
-                <code>import 'react-super-responsive-table/dist/SuperResponsiveTableStyle.css'</code>
+                To enable the base table styles, set the{' '}
+                <code>withBaseStyles</code> prop on the <code>Table</code>{' '}
+                component. You may optionally use it to define a custom
+                breakpoint:{' '}
+                <code>
+                  {"<Table withBaseStyles={{ breakpoint: '45em' }} />"}
+                </code>
+                .
               </li>
-              <li>Write your html table with the imported components</li>
+              <li>Write your html table with the imported components.</li>
             </ol>
           </div>
 
@@ -229,42 +209,79 @@ const theme /*: PrismTheme */ = {
 };
 
 const headerCode = `
-<Table>
-  <Thead>
-    <Tr>
-      <Th>Event</Th>
-      <Th>Date</Th>
-      <Th>Location</Th>
-      <Th>Organizer</Th>
-      <Th>Theme</Th>
-      <Th>Agent</Th>
-    </Tr>
-  </Thead>
-  <Tbody>
-    <Tr>
-      <Td>Tablescon</Td>
-      <Td>9 April 2019</Td>
-      <Td>East Annex</Td>
-      <Td>Super Friends</Td>
-      <Td>Data Tables</Td>
-      <Td>Coston Perkins</Td>
-    </Tr>
-    <Tr>
-      <Td>Capstone Data</Td>
-      <Td>19 May 2019</Td>
-      <Td>205 Gorgas</Td>
-      <Td>Data Underground</Td>
-      <Td>Data Scence</Td>
-      <Td>Jason Phillips</Td>
-    </Tr>
-    <Tr>
-      <Td>Tuscaloosa D3</Td>
-      <Td>29 June 2019</Td>
-      <Td>Github</Td>
-      <Td>The Contributors Consortium</Td>
-      <Td>Data Viz</Td>
-      <Td>Coston Perkins</Td>
-    </Tr>
-  </Tbody>
-</Table>
+<>
+  <style>{\`
+    .super-responsive-table__table {
+      width: 100%;
+      border-collapse: collapse;
+      background: rgba(255, 255, 255, 0.4);
+    }
+
+    .super-responsive-table__th,
+    .super-responsive-table__td {
+      padding: 0.75rem;
+      border: 1px solid #000;
+    }
+
+    .super-responsive-table__th {
+      background: #000;
+      color: #fff;
+      text-align: left;
+      font-weight: bold;
+    }
+
+    @media screen and (max-width: 40em) {
+      .super-responsive-table__tr {
+        border: 1px solid #000;
+      }
+
+      .super-responsive-table__td {
+        border: none;
+      }
+
+      .super-responsive-table__th_pseudo {
+        padding: 0.75rem;
+        font-weight: bold;
+      }
+    }
+  \`}</style>
+  <Table withBaseStyles={{ breakpoint: "40em" }}>
+    <Thead>
+      <Tr>
+        <Th>Event</Th>
+        <Th>Date</Th>
+        <Th>Location</Th>
+        <Th>Organizer</Th>
+        <Th>Theme</Th>
+        <Th>Agent</Th>
+      </Tr>
+    </Thead>
+    <Tbody>
+      <Tr>
+        <Td>Tablescon</Td>
+        <Td>9 April 2019</Td>
+        <Td>East Annex</Td>
+        <Td>Super Friends</Td>
+        <Td>Data Tables</Td>
+        <Td>Coston Perkins</Td>
+      </Tr>
+      <Tr>
+        <Td>Capstone Data</Td>
+        <Td>19 May 2019</Td>
+        <Td>205 Gorgas</Td>
+        <Td>Data Underground</Td>
+        <Td>Data Scence</Td>
+        <Td>Jason Phillips</Td>
+      </Tr>
+      <Tr>
+        <Td>Tuscaloosa D3</Td>
+        <Td>29 June 2019</Td>
+        <Td>Github</Td>
+        <Td>The Contributors Consortium</Td>
+        <Td>Data Viz</Td>
+        <Td>Coston Perkins</Td>
+      </Tr>
+    </Tbody>
+  </Table>
+</>
 `.trim();

--- a/src/SuperResponsiveTable.js
+++ b/src/SuperResponsiveTable.js
@@ -1,12 +1,14 @@
 import React from 'react'
 import { Provider, Consumer } from './tableContext'
+import { injectBaseStyles } from './baseStyleUtils'
 
 const omit = (obj, omitProps) =>
   Object.keys(obj)
     .filter(key => omitProps.indexOf(key) === -1)
     .reduce((returnObj, key) => ({ ...returnObj, [key]: obj[key] }), {})
 
-const allowed = props => omit(props, ['inHeader', 'columnKey', 'headers'])
+const allowed = props =>
+  omit(props, ['inHeader', 'columnKey', 'headers', 'withBaseStyles'])
 
 export class Table extends React.Component {
   constructor(props) {
@@ -15,6 +17,13 @@ export class Table extends React.Component {
       headers: {},
     }
   }
+
+  componentDidMount() {
+    if (this.props.withBaseStyles) {
+      injectBaseStyles()
+    }
+  }
+
   render() {
     const { headers } = this.state
     const classes = (this.props.className || '') + ' responsiveTable'

--- a/src/SuperResponsiveTable.js
+++ b/src/SuperResponsiveTable.js
@@ -2,13 +2,31 @@ import React from 'react'
 import { Provider, Consumer } from './tableContext'
 import { injectBaseStyles } from './baseStyleUtils'
 
+const classes = ({ bem, others }) => {
+  const bemArray = Array.isArray(bem) ? bem : [bem]
+  const othersArray = Array.isArray(others) ? others : [others]
+
+  const allClasses = [
+    ...bemArray.map(name => `super-responsive-table__${name}`),
+    ...othersArray,
+  ].join(' ')
+
+  return allClasses
+}
+
 const omit = (obj, omitProps) =>
   Object.keys(obj)
     .filter(key => omitProps.indexOf(key) === -1)
     .reduce((returnObj, key) => ({ ...returnObj, [key]: obj[key] }), {})
 
 const allowed = props =>
-  omit(props, ['inHeader', 'columnKey', 'headers', 'withBaseStyles'])
+  omit(props, [
+    'inHeader',
+    'columnKey',
+    'headers',
+    'withBaseStyles',
+    'className',
+  ])
 
 export class Table extends React.Component {
   constructor(props) {
@@ -26,13 +44,15 @@ export class Table extends React.Component {
 
   render() {
     const { headers } = this.state
-    const classes = (this.props.className || '') + ' responsiveTable'
     return (
       <Provider value={headers}>
         <table
+          className={classes({
+            bem: 'table',
+            others: ['responsiveTable', this.props.className],
+          })}
           data-testid="table"
           {...allowed(this.props)}
-          className={classes}
         />
       </Provider>
     )
@@ -40,7 +60,11 @@ export class Table extends React.Component {
 }
 
 export const Thead = props => (
-  <thead data-testid="thead" {...allowed(props)}>
+  <thead
+    className={classes({ bem: 'thead', others: props.className })}
+    data-testid="thead"
+    {...allowed(props)}
+  >
     {React.cloneElement(props.children, { inHeader: true })}
   </thead>
 )
@@ -60,7 +84,11 @@ class TrInner extends React.Component {
   render() {
     const { children } = this.props
     return (
-      <tr data-testid="tr" {...allowed(this.props)}>
+      <tr
+        className={classes({ bem: 'tr', others: this.props.className })}
+        data-testid="tr"
+        {...allowed(this.props)}
+      >
         {children &&
           React.Children.map(
             children,
@@ -80,19 +108,50 @@ export const Tr = props => (
   <Consumer>{headers => <TrInner {...props} headers={headers} />}</Consumer>
 )
 
-export const Th = props => <th data-testid="th" {...allowed(props)} />
-export const Tbody = props => <tbody data-testid="tbody" {...allowed(props)} />
+export const Th = props => (
+  <th
+    className={classes({ bem: 'th', others: props.className })}
+    data-testid="th"
+    {...allowed(props)}
+  />
+)
+export const Tbody = props => (
+  <tbody
+    className={classes({ bem: 'tbody', others: props.className })}
+    data-testid="tbody"
+    {...allowed(props)}
+  />
+)
 
 class TdInner extends React.Component {
   render() {
     if (this.props.colSpan) {
-      return <td data-testid="td" {...allowed(this.props)} />
+      return (
+        <td
+          className={classes({
+            bem: 'td',
+            others: this.props.className,
+          })}
+          data-testid="td"
+          {...allowed(this.props)}
+        />
+      )
     }
     const { headers, children, columnKey } = this.props
-    const classes = (this.props.className || '') + ' pivoted'
+
     return (
-      <td data-testid="td" {...allowed(this.props)} className={classes}>
-        <div data-testid="td-before" className="tdBefore">
+      <td
+        className={classes({
+          bem: ['td', 'td_pivoted'],
+          others: ['pivoted', this.props.className],
+        })}
+        data-testid="td"
+        {...allowed(this.props)}
+      >
+        <div
+          className={classes({ bem: 'th_pseudo', others: 'tdBefore' })}
+          data-testid="td-before"
+        >
           {headers[columnKey]}
         </div>
         {children || <div>&nbsp;</div>}

--- a/src/SuperResponsiveTable.js
+++ b/src/SuperResponsiveTable.js
@@ -159,7 +159,7 @@ class TdInner extends React.Component {
         {...allowed(this.props)}
       >
         <div
-          className={classes({ bem: 'th_pseudo', others: 'tdBefore' })}
+          className={classes({ bem: 'th_pivoted', others: 'tdBefore' })}
           data-testid="td-before"
         >
           {headers[columnKey]}

--- a/src/SuperResponsiveTable.js
+++ b/src/SuperResponsiveTable.js
@@ -159,7 +159,7 @@ class TdInner extends React.Component {
         {...allowed(this.props)}
       >
         <div
-          className={classes({ bem: 'th_pivoted', others: 'tdBefore' })}
+          className={classes({ bem: ['th', 'th_pivoted'], others: 'tdBefore' })}
           data-testid="td-before"
         >
           {headers[columnKey]}

--- a/src/SuperResponsiveTable.js
+++ b/src/SuperResponsiveTable.js
@@ -38,7 +38,17 @@ export class Table extends React.Component {
 
   componentDidMount() {
     if (this.props.withBaseStyles) {
-      injectBaseStyles()
+      injectBaseStyles(this.props.withBaseStyles)
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.withBaseStyles &&
+      prevProps.withBaseStyles.breakpoint !==
+        this.props.withBaseStyles.breakpoint
+    ) {
+      injectBaseStyles(this.props.withBaseStyles)
     }
   }
 

--- a/src/baseStyleUtils.js
+++ b/src/baseStyleUtils.js
@@ -40,6 +40,7 @@ const generateBaseStyles = ({ breakpoint = '40em' }) => css`
     top: 0;
     left: -100%;
     width: 100%;
+    height: 100%;
   }
 }
 `

--- a/src/baseStyleUtils.js
+++ b/src/baseStyleUtils.js
@@ -8,7 +8,7 @@ const css = (strings, ...expressions) => {
 }
 
 const generateBaseStyles = ({ breakpoint = '40em' }) => css`
-.super-responsive-table__th_pseudo {
+.super-responsive-table__th_pivoted {
   display: none;
 }
 
@@ -33,7 +33,7 @@ const generateBaseStyles = ({ breakpoint = '40em' }) => css`
     margin-left: 50%;
   }
 
-  .super-responsive-table__th_pseudo {
+  .super-responsive-table__th_pivoted {
     box-sizing: border-box;
     display: block;
     position: absolute;

--- a/src/baseStyleUtils.js
+++ b/src/baseStyleUtils.js
@@ -1,0 +1,44 @@
+const baseStyles = `
+.responsiveTable td .tdBefore {
+  display: none;
+}
+
+@media screen and (max-width: 40em) {
+  .responsiveTable table,
+  .responsiveTable thead,
+  .responsiveTable tbody,
+  .responsiveTable th,
+  .responsiveTable td,
+  .responsiveTable tr {
+    display: block;
+  }
+
+  .responsiveTable thead tr {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+  }
+
+  .responsiveTable td.pivoted {
+    position: relative;
+    margin-left: 50%;
+  }
+
+  .responsiveTable td .tdBefore {
+    box-sizing: border-box;
+    display: block;
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+  }
+}
+`
+
+export const injectBaseStyles = () => {
+  const styleTag = document.createElement('style')
+  styleTag.setAttribute('data-super-responsive-table', '')
+  styleTag.innerHTML = baseStyles
+
+  document.head.appendChild(styleTag)
+}

--- a/src/baseStyleUtils.js
+++ b/src/baseStyleUtils.js
@@ -1,9 +1,18 @@
-const baseStyles = `
+const css = (strings, ...expressions) => {
+  let str = ''
+  strings.forEach((string, i) => {
+    str += string + (expressions[i] || '')
+  })
+
+  return str
+}
+
+const generateBaseStyles = ({ breakpoint = '40em' }) => css`
 .super-responsive-table__th_pseudo {
   display: none;
 }
 
-@media screen and (max-width: 40em) {
+@media screen and (max-width: ${breakpoint}) {
   .super-responsive-table__table,
   .super-responsive-table__thead,
   .super-responsive-table__tbody,
@@ -35,10 +44,23 @@ const baseStyles = `
 }
 `
 
-export const injectBaseStyles = () => {
-  const styleTag = document.createElement('style')
-  styleTag.setAttribute('data-super-responsive-table', '')
-  styleTag.innerHTML = baseStyles
+const getStyleTag = () => {
+  const existingStyleTag = document.head.querySelector(
+    'style[data-super-responsive-table]'
+  )
 
-  document.head.appendChild(styleTag)
+  if (existingStyleTag) {
+    return existingStyleTag
+  }
+
+  const newStyleTag = document.createElement('style')
+  newStyleTag.setAttribute('data-super-responsive-table', '')
+  document.head.appendChild(newStyleTag)
+
+  return newStyleTag
+}
+
+export const injectBaseStyles = props => {
+  const styleTag = getStyleTag()
+  styleTag.innerHTML = generateBaseStyles(props)
 }

--- a/src/baseStyleUtils.js
+++ b/src/baseStyleUtils.js
@@ -1,30 +1,30 @@
 const baseStyles = `
-.responsiveTable td .tdBefore {
+.super-responsive-table__th_pseudo {
   display: none;
 }
 
 @media screen and (max-width: 40em) {
-  .responsiveTable table,
-  .responsiveTable thead,
-  .responsiveTable tbody,
-  .responsiveTable th,
-  .responsiveTable td,
-  .responsiveTable tr {
+  .super-responsive-table__table,
+  .super-responsive-table__thead,
+  .super-responsive-table__tbody,
+  .super-responsive-table__th,
+  .super-responsive-table__td,
+  .super-responsive-table__tr {
     display: block;
   }
 
-  .responsiveTable thead tr {
+  .super-responsive-table__thead {
     position: absolute;
     top: -9999px;
     left: -9999px;
   }
 
-  .responsiveTable td.pivoted {
+  .super-responsive-table__td_pivoted {
     position: relative;
     margin-left: 50%;
   }
 
-  .responsiveTable td .tdBefore {
+  .super-responsive-table__th_pseudo {
     box-sizing: border-box;
     display: block;
     position: absolute;

--- a/src/baseStyleUtils.js
+++ b/src/baseStyleUtils.js
@@ -35,7 +35,6 @@ const generateBaseStyles = ({ breakpoint = '40em' }) => css`
 
   .super-responsive-table__th_pivoted {
     box-sizing: border-box;
-    display: block;
     position: absolute;
     top: 0;
     left: -100%;

--- a/test/SuperResponsiveTable.test.js
+++ b/test/SuperResponsiveTable.test.js
@@ -1,9 +1,22 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
-import { Table, Thead, Tbody, Tr, Th, Td } from '../src/SuperResponsiveTable'
+import * as baseStyleUtils from '../src/baseStyleUtils'
+import {
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TBaseStyles,
+} from '../src/SuperResponsiveTable'
 
 describe('SuperResponsiveTable', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   // START OF COMPONENT SETUP
   const setup = (ui, options) => {
     const defaultUi = (
@@ -80,6 +93,82 @@ describe('SuperResponsiveTable', () => {
     const { getTdBefore } = setup()
 
     expect(getTdBefore.length).toBe(3)
+  })
+
+  it('does not call injectBaseStyles on mount', () => {
+    jest.spyOn(baseStyleUtils, 'injectBaseStyles')
+    setup()
+
+    expect(baseStyleUtils.injectBaseStyles).not.toHaveBeenCalled()
+  })
+
+  describe('withBaseStyles is truthy', () => {
+    it('calls injectBaseStyles on mount', () => {
+      jest.spyOn(baseStyleUtils, 'injectBaseStyles')
+      setup(
+        <Table withBaseStyles>
+          <Thead>
+            <Tr>
+              <Th>Header 1</Th>
+              <Th>Header 2</Th>
+              <Th>Header 3</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            <Tr>
+              <Td>Row 1</Td>
+              <Td>Row 2</Td>
+              <Td>Row 3</Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      )
+
+      expect(baseStyleUtils.injectBaseStyles).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls injectBaseStyles again if props have changed', () => {
+      jest.spyOn(baseStyleUtils, 'injectBaseStyles')
+      const { rerender } = setup(
+        <Table withBaseStyles={{ breakpoint: '40em' }}>
+          <Thead>
+            <Tr>
+              <Th>Header 1</Th>
+              <Th>Header 2</Th>
+              <Th>Header 3</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            <Tr>
+              <Td>Row 1</Td>
+              <Td>Row 2</Td>
+              <Td>Row 3</Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      )
+
+      rerender(
+        <Table withBaseStyles={{ breakpoint: '45em' }}>
+          <Thead>
+            <Tr>
+              <Th>Header 1</Th>
+              <Th>Header 2</Th>
+              <Th>Header 3</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            <Tr>
+              <Td>Row 1</Td>
+              <Td>Row 2</Td>
+              <Td>Row 3</Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      )
+
+      expect(baseStyleUtils.injectBaseStyles).toHaveBeenCalledTimes(2)
+    })
   })
 })
 

--- a/test/SuperResponsiveTable.test.js
+++ b/test/SuperResponsiveTable.test.js
@@ -5,8 +5,8 @@ import { Table, Thead, Tbody, Tr, Th, Td } from '../src/SuperResponsiveTable'
 
 describe('SuperResponsiveTable', () => {
   // START OF COMPONENT SETUP
-  const setup = overrides => {
-    const { getAllByTestId, getByTestId, getAllByText } = render(
+  const setup = (ui, options) => {
+    const defaultUi = (
       <Table>
         <Thead>
           <Tr>
@@ -24,9 +24,11 @@ describe('SuperResponsiveTable', () => {
         </Tbody>
       </Table>
     )
+    const renderResult = render(ui || defaultUi, options)
+    const { getAllByTestId, getByTestId } = renderResult
 
     return {
-      getAllByText,
+      ...renderResult,
       getTable: getByTestId('table'),
       getThead: getByTestId('thead'),
       getTr: getAllByTestId('tr'),

--- a/test/SuperResponsiveTable.test.js
+++ b/test/SuperResponsiveTable.test.js
@@ -170,6 +170,34 @@ describe('SuperResponsiveTable', () => {
       expect(baseStyleUtils.injectBaseStyles).toHaveBeenCalledTimes(2)
     })
   })
+
+  it('appends custom classes to table elements', () => {
+    const { getTable, getThead, getTr, getTh, getTbody, getTd } = setup(
+      <Table className="my-table">
+        <Thead className="my-thead">
+          <Tr className="my-tr">
+            <Th className="my-th">Header 1</Th>
+            <Th>Header 2</Th>
+            <Th>Header 3</Th>
+          </Tr>
+        </Thead>
+        <Tbody className="my-tbody">
+          <Tr>
+            <Td className="my-td">Row 1</Td>
+            <Td>Row 2</Td>
+            <Td>Row 3</Td>
+          </Tr>
+        </Tbody>
+      </Table>
+    )
+
+    expect(getTable).toHaveClass('my-table')
+    expect(getThead).toHaveClass('my-thead')
+    expect(getTr[0]).toHaveClass('my-tr')
+    expect(getTh[0]).toHaveClass('my-th')
+    expect(getTbody).toHaveClass('my-tbody')
+    expect(getTd[0]).toHaveClass('my-td')
+  })
 })
 
 // TODO


### PR DESCRIPTION
## Description

Closes https://github.com/ua-oira/react-super-responsive-table/issues/128
- Simplifies styling process by introducing `withBaseStyles` prop
- The base styles are:
  - Minimal and unopinionated
  - Dynamically injected via BEM-style class names for minimum possible specificity
- Introduces `breakpoint` option within `withBaseStyles` prop to allow for a custom breakpoint

```jsx
<Table withBaseStyles={{ breakpoint: "45em" }} />
```

## Types of changes

<!--- Leave the one fitting to your PR  -->

- New feature (non-breaking change which adds functionality)
  - I've taken care to make sure this does not introduce any breaking changes—though I think a future major version of this library should ship with the base styles by default

## Checklist:

<!--- Go over all the following points and make sure you have done all of those -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation I have updated the documentation accordingly.
